### PR TITLE
refactor: remove barrel files except for modules

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -3,14 +3,12 @@ import { randomBytes } from "crypto";
 import { createWalletClient, http } from "viem";
 
 import { FOLKS_CHAIN_ID } from "../src/common/constants/chain.js";
-import {
-  NetworkType,
-  FolksCore,
-  FolksAccount,
-  AdapterType,
-} from "../src/index.js";
+import { NetworkType } from "../src/common/types/chain.js";
+import { AdapterType } from "../src/common/types/message.js";
+import { FolksCore, FolksAccount } from "../src/index.js";
 
-import type { FolksCoreConfig, MessageAdapters } from "../src/index.js";
+import type { FolksCoreConfig } from "../src/common/types/core.js";
+import type { MessageAdapters } from "../src/common/types/message.js";
 import type { Hex } from "viem";
 
 async function main() {

--- a/src/chains/evm/common/constants/abi/index.ts
+++ b/src/chains/evm/common/constants/abi/index.ts
@@ -1,1 +1,0 @@
-export * from "./erc-20-abi.js";

--- a/src/chains/evm/common/constants/chain.ts
+++ b/src/chains/evm/common/constants/chain.ts
@@ -1,8 +1,8 @@
 import { avalancheFuji, baseSepolia, sepolia } from "viem/chains";
 
-import { FOLKS_CHAIN_ID } from "../../../../common/constants/index.js";
+import { FOLKS_CHAIN_ID } from "../../../../common/constants/chain.js";
 
-import type { FolksChainId } from "../../../../common/types/index.js";
+import type { FolksChainId } from "../../../../common/types/chain.js";
 import type { Chain } from "viem";
 
 export const CHAIN_VIEM: Record<FolksChainId, Chain> = {

--- a/src/chains/evm/common/constants/index.ts
+++ b/src/chains/evm/common/constants/index.ts
@@ -1,1 +1,0 @@
-export * from "./chain.js";

--- a/src/chains/evm/common/types/module.ts
+++ b/src/chains/evm/common/types/module.ts
@@ -1,8 +1,8 @@
+import type { MessageAdapters } from "../../../../common/types/message.js";
 import type {
-  ListedToken,
-  MessageAdapters,
   SpokeTokenData,
-} from "../../../../common/types/index.js";
+  ListedToken,
+} from "../../../../common/types/token.js";
 import type { Address } from "viem";
 
 export type PrepareCall = {

--- a/src/chains/evm/common/utils/contract.ts
+++ b/src/chains/evm/common/utils/contract.ts
@@ -1,12 +1,12 @@
 import { getContract } from "viem";
 
-import { ChainType } from "../../../../common/types/index.js";
+import { ChainType } from "../../../../common/types/chain.js";
 import { convertFromGenericAddress } from "../../../../common/utils/address.js";
-import { ERC20Abi } from "../constants/abi/index.js";
+import { ERC20Abi } from "../constants/abi/erc-20-abi.js";
 
 import { getSignerAddress } from "./chain.js";
 
-import type { GenericAddress } from "../../../../common/types/index.js";
+import type { GenericAddress } from "../../../../common/types/chain.js";
 import type { Address, PublicClient, WalletClient } from "viem";
 
 export function getERC20Contract(

--- a/src/chains/evm/common/utils/index.ts
+++ b/src/chains/evm/common/utils/index.ts
@@ -1,3 +1,0 @@
-export * from "./chain.js";
-export * from "./contract.js";
-export * from "./provider.js";

--- a/src/chains/evm/common/utils/provider.ts
+++ b/src/chains/evm/common/utils/provider.ts
@@ -1,10 +1,10 @@
 import { createPublicClient, fallback, http } from "viem";
 
-import { FOLKS_CHAIN_ID } from "../../../../common/constants/index.js";
-import { CHAIN_NODE, CHAIN_VIEM } from "../constants/index.js";
+import { FOLKS_CHAIN_ID } from "../../../../common/constants/chain.js";
+import { CHAIN_VIEM, CHAIN_NODE } from "../constants/chain.js";
 
-import type { FolksChainId } from "../../../../common/types/index.js";
-import type { ChainId } from "../types/index.js";
+import type { FolksChainId } from "../../../../common/types/chain.js";
+import type { ChainId } from "../types/chain.js";
 import type { PublicClient } from "viem";
 
 export function initProviders(

--- a/src/chains/evm/hub/constants/abi/index.ts
+++ b/src/chains/evm/hub/constants/abi/index.ts
@@ -1,2 +1,0 @@
-export * from "./account-manager-abi.js";
-export * from "./bridge-router-hub-abi.js";

--- a/src/chains/evm/hub/constants/chain.ts
+++ b/src/chains/evm/hub/constants/chain.ts
@@ -1,16 +1,12 @@
-import { FOLKS_CHAIN_ID } from "../../../../common/constants/index.js";
-import {
-  AdapterType,
-  ChainType,
-  NetworkType,
-} from "../../../../common/types/index.js";
-import { convertToGenericAddress } from "../../../../common/utils/index.js";
+import { FOLKS_CHAIN_ID } from "../../../../common/constants/chain.js";
+import { NetworkType, ChainType } from "../../../../common/types/chain.js";
+import { AdapterType } from "../../../../common/types/message.js";
+import { convertToGenericAddress } from "../../../../common/utils/address.js";
 
-import type {
-  FolksChainId,
-  FolksTokenId,
-} from "../../../../common/types/index.js";
-import type { HubChain, HubTokenData } from "../types/index.js";
+import type { FolksChainId } from "../../../../common/types/chain.js";
+import type { FolksTokenId } from "../../../../common/types/token.js";
+import type { HubChain } from "../types/chain.js";
+import type { HubTokenData } from "../types/token.js";
 
 export const HUB_CHAIN: Record<NetworkType, HubChain> = {
   [NetworkType.MAINNET]: {

--- a/src/chains/evm/hub/constants/index.ts
+++ b/src/chains/evm/hub/constants/index.ts
@@ -1,1 +1,0 @@
-export * from "./chain.js";

--- a/src/chains/evm/hub/modules/folks-hub-account.ts
+++ b/src/chains/evm/hub/modules/folks-hub-account.ts
@@ -1,11 +1,12 @@
 import { getFolksChainIdsByNetwork } from "../../../../common/utils/chain.js";
-import { getAccountManagerContract, getHubChain } from "../utils/index.js";
+import { getHubChain } from "../utils/chain.js";
+import { getAccountManagerContract } from "../utils/contract.js";
 
 import type {
   NetworkType,
   FolksChainId,
-} from "../../../../common/types/index.js";
-import type { AccountInfo } from "../types/index.js";
+} from "../../../../common/types/chain.js";
+import type { AccountInfo } from "../types/account.js";
 import type { Address, Hex, PublicClient } from "viem";
 
 export async function getAccountInfo(

--- a/src/chains/evm/hub/modules/folks-hub-loan.ts
+++ b/src/chains/evm/hub/modules/folks-hub-loan.ts
@@ -1,27 +1,29 @@
+import { UINT256_LENGTH } from "../../../../common/constants/bytes.js";
+import { FINALITY } from "../../../../common/constants/message.js";
+import { Action } from "../../../../common/types/message.js";
+import { getRandomGenericAddress } from "../../../../common/utils/address.js";
+import { convertNumberToBytes } from "../../../../common/utils/bytes.js";
 import {
-  FINALITY,
-  UINT256_LENGTH,
-} from "../../../../common/constants/index.js";
-import { Action } from "../../../../common/types/index.js";
+  getSpokeChain,
+  getSpokeTokenData,
+} from "../../../../common/utils/chain.js";
 import {
   DEFAULT_MESSAGE_PARAMS,
   buildMessagePayload,
-  convertNumberToBytes,
-  getRandomGenericAddress,
   getSendTokenExtraArgsWhenRemoving,
-  getSpokeChain,
-  getSpokeTokenData,
-} from "../../../../common/utils/index.js";
+} from "../../../../common/utils/messages.js";
 import { getHubChain, getHubTokenData } from "../utils/chain.js";
 import { getBridgeRouterHubContract } from "../utils/contract.js";
 
 import type {
+  NetworkType,
   FolksChainId,
+} from "../../../../common/types/chain.js";
+import type {
   MessageAdapters,
   MessageToSend,
-  FolksTokenId,
-  NetworkType,
-} from "../../../../common/types/index.js";
+} from "../../../../common/types/message.js";
+import type { FolksTokenId } from "../../../../common/types/token.js";
 import type { Hex, PublicClient } from "viem";
 
 export function getSendTokenAdapterFees(

--- a/src/chains/evm/hub/types/chain.ts
+++ b/src/chains/evm/hub/types/chain.ts
@@ -1,10 +1,10 @@
 import type { HubTokenData } from "./token.js";
 import type {
-  AdapterType,
-  FolksTokenId,
   GenericAddress,
   IFolksChain,
-} from "../../../../common/types/index.js";
+} from "../../../../common/types/chain.js";
+import type { AdapterType } from "../../../../common/types/message.js";
+import type { FolksTokenId } from "../../../../common/types/token.js";
 
 export type HubChain = {
   hubAddress: GenericAddress;

--- a/src/chains/evm/hub/types/index.ts
+++ b/src/chains/evm/hub/types/index.ts
@@ -1,3 +1,0 @@
-export * from "./account.js";
-export * from "./chain.js";
-export * from "./token.js";

--- a/src/chains/evm/hub/types/token.ts
+++ b/src/chains/evm/hub/types/token.ts
@@ -1,8 +1,6 @@
-import type {
-  LoanType,
-  GenericAddress,
-  ITokenData,
-} from "../../../../common/types/index.js";
+import type { GenericAddress } from "../../../../common/types/chain.js";
+import type { LoanType } from "../../../../common/types/module.js";
+import type { ITokenData } from "../../../../common/types/token.js";
 
 export type HubTokenData = {
   poolId: number;

--- a/src/chains/evm/hub/utils/chain.ts
+++ b/src/chains/evm/hub/utils/chain.ts
@@ -1,12 +1,13 @@
-import { HUB_CHAIN } from "../constants/index.js";
+import { HUB_CHAIN } from "../constants/chain.js";
 
 import type {
-  FolksTokenId,
-  LoanType,
-  NetworkType,
   FolksChainId,
-} from "../../../../common/types/index.js";
-import type { HubChain, HubTokenData } from "../types/index.js";
+  NetworkType,
+} from "../../../../common/types/chain.js";
+import type { LoanType } from "../../../../common/types/module.js";
+import type { FolksTokenId } from "../../../../common/types/token.js";
+import type { HubChain } from "../types/chain.js";
+import type { HubTokenData } from "../types/token.js";
 
 export function isHubChain(
   folksChainId: FolksChainId,

--- a/src/chains/evm/hub/utils/contract.ts
+++ b/src/chains/evm/hub/utils/contract.ts
@@ -2,13 +2,11 @@ import { getContract } from "viem";
 
 import { ChainType } from "../../../../common/types/chain.js";
 import { convertFromGenericAddress } from "../../../../common/utils/address.js";
-import {
-  AccountManagerAbi,
-  BridgeRouterHubAbi,
-} from "../constants/abi/index.js";
+import { AccountManagerAbi } from "../constants/abi/account-manager-abi.js";
+import { BridgeRouterHubAbi } from "../constants/abi/bridge-router-hub-abi.js";
 
 import type { GenericAddress } from "../../../../common/types/chain.js";
-import type { GetReadContractReturnType } from "../../common/types/index.js";
+import type { GetReadContractReturnType } from "../../common/types/contract.js";
 import type { Address, PublicClient, WalletClient } from "viem";
 
 export function getAccountManagerContract(

--- a/src/chains/evm/hub/utils/index.ts
+++ b/src/chains/evm/hub/utils/index.ts
@@ -1,2 +1,0 @@
-export * from "./chain.js";
-export * from "./contract.js";

--- a/src/chains/evm/spoke/constants/abi/index.ts
+++ b/src/chains/evm/spoke/constants/abi/index.ts
@@ -1,3 +1,0 @@
-export * from "./bridge-router-spoke-abi.js";
-export * from "./spoke-common-abi.js";
-export * from "./spoke-token-abi.js";

--- a/src/chains/evm/spoke/modules/folks-evm-account.ts
+++ b/src/chains/evm/spoke/modules/folks-evm-account.ts
@@ -1,16 +1,20 @@
 import { concat } from "viem";
 
-import { FINALITY, UINT16_LENGTH } from "../../../../common/constants/index.js";
-import { Action, ChainType } from "../../../../common/types/index.js";
+import { UINT16_LENGTH } from "../../../../common/constants/bytes.js";
+import { FINALITY } from "../../../../common/constants/message.js";
+import { ChainType } from "../../../../common/types/chain.js";
+import { Action } from "../../../../common/types/message.js";
+import {
+  getRandomGenericAddress,
+  convertToGenericAddress,
+} from "../../../../common/utils/address.js";
+import { convertNumberToBytes } from "../../../../common/utils/bytes.js";
+import { getSpokeChain } from "../../../../common/utils/chain.js";
 import {
   DEFAULT_MESSAGE_PARAMS,
   buildMessagePayload,
-  convertNumberToBytes,
-  convertToGenericAddress,
-  getRandomGenericAddress,
-  getSpokeChain,
-} from "../../../../common/utils/index.js";
-import { getSignerAddress } from "../../common/utils/index.js";
+} from "../../../../common/utils/messages.js";
+import { getSignerAddress } from "../../common/utils/chain.js";
 import { getHubChain } from "../../hub/utils/chain.js";
 import {
   getBridgeRouterSpokeContract,
@@ -19,18 +23,20 @@ import {
 
 import type {
   FolksChainId,
-  MessageAdapters,
-  MessageParams,
-  MessageToSend,
   SpokeChain,
   NetworkType,
-} from "../../../../common/types/index.js";
+} from "../../../../common/types/chain.js";
 import type {
-  PrepareAcceptInviteAddressCall,
+  MessageAdapters,
+  MessageToSend,
+  MessageParams,
+} from "../../../../common/types/message.js";
+import type {
   PrepareCreateAccountCall,
   PrepareInviteAddressCall,
+  PrepareAcceptInviteAddressCall,
   PrepareUnregisterAddressCall,
-} from "../../common/types/index.js";
+} from "../../common/types/module.js";
 import type {
   Address,
   EstimateGasParameters,

--- a/src/chains/evm/spoke/modules/folks-evm-loan.ts
+++ b/src/chains/evm/spoke/modules/folks-evm-loan.ts
@@ -1,12 +1,13 @@
 import { concat } from "viem";
 
 import {
-  FINALITY,
   UINT16_LENGTH,
-  UINT256_LENGTH,
   UINT8_LENGTH,
-} from "../../../../common/constants/index.js";
-import { Action, TokenType } from "../../../../common/types/index.js";
+  UINT256_LENGTH,
+} from "../../../../common/constants/bytes.js";
+import { FINALITY } from "../../../../common/constants/message.js";
+import { Action } from "../../../../common/types/message.js";
+import { TokenType } from "../../../../common/types/token.js";
 import { getRandomGenericAddress } from "../../../../common/utils/address.js";
 import {
   convertNumberToBytes,
@@ -21,10 +22,8 @@ import {
   buildMessagePayload,
   getSendTokenExtraArgsWhenAdding,
 } from "../../../../common/utils/messages.js";
-import {
-  getSignerAddress,
-  sendERC20Approve,
-} from "../../common/utils/index.js";
+import { getSignerAddress } from "../../common/utils/chain.js";
+import { sendERC20Approve } from "../../common/utils/contract.js";
 import { getHubChain, getHubTokenData } from "../../hub/utils/chain.js";
 import {
   getBridgeRouterSpokeContract,
@@ -34,19 +33,21 @@ import {
 
 import type {
   FolksChainId,
-  MessageAdapters,
-  MessageParams,
-  MessageToSend,
-  SpokeChain,
-  FolksTokenId,
   NetworkType,
-} from "../../../../common/types/index.js";
+  SpokeChain,
+} from "../../../../common/types/chain.js";
+import type {
+  MessageAdapters,
+  MessageToSend,
+  MessageParams,
+} from "../../../../common/types/message.js";
+import type { FolksTokenId } from "../../../../common/types/token.js";
 import type {
   PrepareCreateLoanCall,
   PrepareDeleteLoanCall,
   PrepareDepositCall,
   PrepareWithdrawCall,
-} from "../../common/types/index.js";
+} from "../../common/types/module.js";
 import type {
   EstimateGasParameters,
   Hex,

--- a/src/chains/evm/spoke/utils/contract.ts
+++ b/src/chains/evm/spoke/utils/contract.ts
@@ -1,14 +1,12 @@
 import { getContract } from "viem";
 
-import { ChainType } from "../../../../common/types/index.js";
+import { ChainType } from "../../../../common/types/chain.js";
 import { convertFromGenericAddress } from "../../../../common/utils/address.js";
-import {
-  BridgeRouterSpokeAbi,
-  SpokeCommonAbi,
-  SpokeTokenAbi,
-} from "../constants/abi/index.js";
+import { BridgeRouterSpokeAbi } from "../constants/abi/bridge-router-spoke-abi.js";
+import { SpokeCommonAbi } from "../constants/abi/spoke-common-abi.js";
+import { SpokeTokenAbi } from "../constants/abi/spoke-token-abi.js";
 
-import type { GenericAddress } from "../../../../common/types/index.js";
+import type { GenericAddress } from "../../../../common/types/chain.js";
 import type { GetReadContractReturnType } from "../../common/types/contract.js";
 import type { GetContractReturnType, PublicClient, WalletClient } from "viem";
 

--- a/src/common/constants/chain.ts
+++ b/src/common/constants/chain.ts
@@ -1,9 +1,10 @@
 import { avalancheFuji, baseSepolia, sepolia } from "viem/chains";
 
-import { AdapterType, ChainType, NetworkType } from "../types/index.js";
+import { NetworkType, ChainType } from "../types/chain.js";
+import { AdapterType } from "../types/message.js";
 import { convertToGenericAddress } from "../utils/address.js";
 
-import type { FolksChain, FolksChainId, SpokeChain } from "../types/index.js";
+import type { FolksChainId, FolksChain, SpokeChain } from "../types/chain.js";
 
 export const MAINNET_FOLKS_CHAIN_ID = {} as const;
 

--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -1,3 +1,0 @@
-export * from "./bytes.js";
-export * from "./chain.js";
-export * from "./message.js";

--- a/src/common/types/chain.ts
+++ b/src/common/types/chain.ts
@@ -1,6 +1,6 @@
 import type { AdapterType } from "./message.js";
 import type { FolksTokenId, SpokeTokenData } from "./token.js";
-import type { FOLKS_CHAIN_ID } from "../constants/index.js";
+import type { FOLKS_CHAIN_ID } from "../constants/chain.js";
 
 export enum ChainType {
   EVM = "EVM",

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,5 +1,0 @@
-export * from "./chain.js";
-export * from "./core.js";
-export * from "./message.js";
-export * from "./module.js";
-export * from "./token.js";

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1,5 +1,5 @@
 import type { GenericAddress } from "./chain.js";
-import type { FINALITY } from "../constants/index.js";
+import type { FINALITY } from "../constants/message.js";
 import type { Hex } from "viem";
 
 export enum AdapterType {

--- a/src/common/types/module.ts
+++ b/src/common/types/module.ts
@@ -8,7 +8,7 @@ import type {
   PrepareDepositCall as PrepareDepositEVMCall,
   PrepareWithdrawCall as PrepareWithdrawEVMCall,
   PrepareCall as PrepareEVMCall,
-} from "../../chains/evm/common/types/index.js";
+} from "../../chains/evm/common/types/module.js";
 
 export enum LoanType {
   DEPOSIT = 1, // no support for borrows

--- a/src/common/utils/adapter.ts
+++ b/src/common/utils/adapter.ts
@@ -1,8 +1,8 @@
 import { isHubChain } from "../../chains/evm/hub/utils/chain.js";
 import { FolksCore } from "../../xchain/core/folks-core.js";
-import { AdapterType } from "../types/index.js";
+import { AdapterType } from "../types/message.js";
 
-import type { FolksChainId } from "../types/index.js";
+import type { FolksChainId } from "../types/chain.js";
 
 export function doesAdapterSupportDataMessage(
   folksChainId: FolksChainId,

--- a/src/common/utils/address.ts
+++ b/src/common/utils/address.ts
@@ -5,11 +5,11 @@ import { exhaustiveCheck } from "../../utils/exhaustive-check.js";
 import {
   BYTES32_LENGTH,
   EVM_ADDRESS_BYTES_LENGTH,
-} from "../constants/index.js";
-import { ChainType } from "../types/index.js";
+} from "../constants/bytes.js";
+import { ChainType } from "../types/chain.js";
 
 import type { AddressType } from "../types/address.js";
-import type { GenericAddress } from "../types/index.js";
+import type { GenericAddress } from "../types/chain.js";
 import type { Address } from "viem";
 
 export function getRandomGenericAddress(): GenericAddress {

--- a/src/common/utils/bytes.ts
+++ b/src/common/utils/bytes.ts
@@ -1,6 +1,6 @@
 import { bytesToHex, pad, toHex } from "viem";
 
-import { BYTES32_LENGTH } from "../constants/index.js";
+import { BYTES32_LENGTH } from "../constants/bytes.js";
 
 import type { Hex } from "viem";
 

--- a/src/common/utils/chain.ts
+++ b/src/common/utils/chain.ts
@@ -1,13 +1,12 @@
-import { FOLKS_CHAIN, SPOKE_CHAIN } from "../constants/index.js";
+import { FOLKS_CHAIN, SPOKE_CHAIN } from "../constants/chain.js";
 
 import type {
-  FolksTokenId,
+  FolksChainId,
   NetworkType,
   FolksChain,
-  FolksChainId,
   SpokeChain,
-  SpokeTokenData,
-} from "../types/index.js";
+} from "../types/chain.js";
+import type { FolksTokenId, SpokeTokenData } from "../types/token.js";
 
 export function getFolksChain(
   folksChainId: FolksChainId,

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,5 +1,0 @@
-export * from "./adapter.js";
-export * from "./address.js";
-export * from "./chain.js";
-export * from "./bytes.js";
-export * from "./messages.js";

--- a/src/common/utils/messages.ts
+++ b/src/common/utils/messages.ts
@@ -1,19 +1,19 @@
 import { concat, isHex } from "viem";
 
-import { UINT16_LENGTH, UINT256_LENGTH } from "../constants/index.js";
-import { TokenType } from "../types/index.js";
+import { UINT16_LENGTH, UINT256_LENGTH } from "../constants/bytes.js";
+import { TokenType } from "../types/token.js";
 
 import { isGenericAddress } from "./address.js";
 import { convertNumberToBytes } from "./bytes.js";
 
-import type { HubTokenData } from "../../chains/evm/hub/types/index.js";
+import type { HubTokenData } from "../../chains/evm/hub/types/token.js";
+import type { GenericAddress } from "../types/chain.js";
 import type {
-  GenericAddress,
   MessageAdapters,
   MessageParams,
-  SpokeTokenData,
   Action,
-} from "../types/index.js";
+} from "../types/message.js";
+import type { SpokeTokenData } from "../types/token.js";
 import type { Hex } from "viem";
 
 export const DEFAULT_MESSAGE_PARAMS = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,17 @@
+// CORE
 export { FolksCore } from "./xchain/core/folks-core.js";
+
+// MODULES
 export { FolksAccount, FolksLoan } from "./xchain/modules/index.js";
-export * from "./common/types/index.js";
-export * from "./common/constants/index.js";
+
+// COMMON
+export * from "./common/types/address.js";
+export * from "./common/types/chain.js";
+export * from "./common/types/core.js";
+export * from "./common/types/message.js";
+export * from "./common/types/module.js";
+export * from "./common/types/token.js";
+
+export * from "./common/constants/bytes.js";
+export * from "./common/constants/chain.js";
+export * from "./common/constants/message.js";

--- a/src/xchain/core/folks-core.ts
+++ b/src/xchain/core/folks-core.ts
@@ -1,20 +1,22 @@
 import { initProviders } from "../../chains/evm/common/utils/provider.js";
 import { getHubChain } from "../../chains/evm/hub/utils/chain.js";
-import { ChainType } from "../../common/types/index.js";
+import { ChainType } from "../../common/types/chain.js";
 import { getFolksChain } from "../../common/utils/chain.js";
 import { exhaustiveCheck } from "../../utils/exhaustive-check.js";
 
 import type {
-  FolksChain,
   FolksChainId,
-  FolksCoreConfig,
-  FolksCoreProvider,
-  FolksProvider,
-  FolksProviderType,
-  FolksSigner,
-  FolksSignerType,
+  FolksChain,
   NetworkType,
-} from "../../common/types/index.js";
+} from "../../common/types/chain.js";
+import type {
+  FolksCoreProvider,
+  FolksSigner,
+  FolksCoreConfig,
+  FolksProviderType,
+  FolksSignerType,
+  FolksProvider,
+} from "../../common/types/core.js";
 import type { PublicClient as EVMProvider } from "viem";
 
 export class FolksCore {

--- a/src/xchain/modules/folks-account.ts
+++ b/src/xchain/modules/folks-account.ts
@@ -1,19 +1,19 @@
 import { FolksHubAccount } from "../../chains/evm/hub/modules/index.js";
 import { FolksEvmAccount } from "../../chains/evm/spoke/modules/index.js";
-import { ChainType } from "../../common/types/index.js";
+import { ChainType } from "../../common/types/chain.js";
 import { assertAdapterSupportsDataMessage } from "../../common/utils/adapter.js";
 import { assertSpokeChainSupported } from "../../common/utils/chain.js";
 import { exhaustiveCheck } from "../../utils/exhaustive-check.js";
 import { FolksCore } from "../core/folks-core.js";
 
+import type { FolksChainId } from "../../common/types/chain.js";
+import type { MessageAdapters } from "../../common/types/message.js";
 import type {
-  FolksChainId,
-  MessageAdapters,
-  PrepareAcceptInviteAddressCall,
   PrepareCreateAccountCall,
   PrepareInviteAddressCall,
+  PrepareAcceptInviteAddressCall,
   PrepareUnregisterAddressCall,
-} from "../../common/types/index.js";
+} from "../../common/types/module.js";
 import type { Address, Hex } from "viem";
 
 export const prepare = {

--- a/src/xchain/modules/folks-loan.ts
+++ b/src/xchain/modules/folks-loan.ts
@@ -4,7 +4,7 @@ import {
   getHubTokenData,
 } from "../../chains/evm/hub/utils/chain.js";
 import { FolksEvmLoan } from "../../chains/evm/spoke/modules/index.js";
-import { ChainType } from "../../common/types/index.js";
+import { ChainType } from "../../common/types/chain.js";
 import {
   assertAdapterSupportsDataMessage,
   assertAdapterSupportsTokenMessage,
@@ -16,15 +16,15 @@ import {
 import { exhaustiveCheck } from "../../utils/exhaustive-check.js";
 import { FolksCore } from "../core/folks-core.js";
 
+import type { FolksChainId } from "../../common/types/chain.js";
+import type { MessageAdapters } from "../../common/types/message.js";
 import type {
-  FolksChainId,
-  MessageAdapters,
+  LoanType,
   PrepareCreateLoanCall,
   PrepareDepositCall,
   PrepareWithdrawCall,
-  FolksTokenId,
-  LoanType,
-} from "../../common/types/index.js";
+} from "../../common/types/module.js";
+import type { FolksTokenId } from "../../common/types/token.js";
 import type { Hex } from "viem";
 
 export const prepare = {


### PR DESCRIPTION
Remove barrel files to reduce likeliness of dependency cycles and improve performance.
Keep them on `modules/*` to do namespace re-exports.

https://flaming.codes/posts/barrel-files-in-javascript/
https://vercel.com/blog/how-we-optimized-package-imports-in-next-js