### PR TITLE
refactor: update token data types

### DIFF
--- a/src/chains/evm/hub/types/token.ts
+++ b/src/chains/evm/hub/types/token.ts
@@ -1,11 +1,12 @@
 import type { GenericAddress } from "../../../../common/types/chain.js";
 import type { LoanType } from "../../../../common/types/module.js";
-import type { ITokenData } from "../../../../common/types/token.js";
+import type { ITokenData, TokenType } from "../../../../common/types/token.js";
 
 export type HubTokenData = {
+  tokenType: TokenType;
   poolId: number;
   poolAddress: GenericAddress;
-  tokenAddress: GenericAddress;
+  tokenAddress: GenericAddress | null;
   tokenDecimals: number;
   supportedLoanTypes: Set<LoanType>;
 } & ITokenData;

--- a/src/common/types/token.ts
+++ b/src/common/types/token.ts
@@ -17,7 +17,8 @@ export type ITokenData = {
 
 export type SpokeTokenData = {
   tokenType: TokenType;
+  poolId: number;
   spokeAddress: GenericAddress;
-  tokenAddress: GenericAddress;
+  tokenAddress: GenericAddress | null;
   tokenDecimals: number;
 } & ITokenData;


### PR DESCRIPTION
Token address can be null on spoke if native gas token
Token address can be null on hub if token is not bridged

Made `poolId` and `tokenType` available on both spoke and hub