### PR TITLE
refactor: use client instead of public-client

### DIFF
--- a/src/chains/evm/common/types/contract.ts
+++ b/src/chains/evm/common/types/contract.ts
@@ -1,6 +1,6 @@
-import type { Abi, GetContractReturnType, PublicClient } from "viem";
+import type { Abi, GetContractReturnType, Client } from "viem";
 
 type OmitWrite<T> = Omit<T, "write">;
 export type GetReadContractReturnType<TAbi extends Abi> = OmitWrite<
-  GetContractReturnType<TAbi, PublicClient>
+  GetContractReturnType<TAbi, Client>
 >;

--- a/src/chains/evm/common/utils/contract.ts
+++ b/src/chains/evm/common/utils/contract.ts
@@ -7,10 +7,10 @@ import { ERC20Abi } from "../constants/abi/erc-20-abi.js";
 import { getSignerAccount, getSignerAddress } from "./chain.js";
 
 import type { GenericAddress } from "../../../../common/types/chain.js";
-import type { Address, PublicClient, WalletClient } from "viem";
+import type { Address, Client, WalletClient } from "viem";
 
 export function getERC20Contract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer: WalletClient,
 ) {
@@ -22,7 +22,7 @@ export function getERC20Contract(
 }
 
 export async function sendERC20Approve(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer: WalletClient,
   receiver: Address,

--- a/src/chains/evm/common/utils/provider.ts
+++ b/src/chains/evm/common/utils/provider.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, fallback, http } from "viem";
+import { createClient, fallback, http } from "viem";
 
 import {
   CHAIN_VIEM,
@@ -10,17 +10,17 @@ import { isEvmChainId } from "./chain.js";
 
 import type { FolksChainId } from "../../../../common/types/chain.js";
 import type { EvmChainId } from "../types/chain.js";
-import type { PublicClient } from "viem";
+import type { Client } from "viem";
 
 export function initProviders(
-  customProvider: Partial<Record<FolksChainId, PublicClient>>,
-): Record<FolksChainId, PublicClient> {
+  customProvider: Partial<Record<FolksChainId, Client>>,
+): Record<FolksChainId, Client> {
   return Object.fromEntries(
     Object.values(EVM_FOLKS_CHAIN_ID).map((evmFolksChainId) => {
       return [
         evmFolksChainId,
         customProvider[evmFolksChainId] ??
-          createPublicClient({
+          createClient({
             chain: CHAIN_VIEM[evmFolksChainId],
             transport: fallback(
               CHAIN_NODE[evmFolksChainId].map((url: string) => http(url)),
@@ -28,10 +28,10 @@ export function initProviders(
           }),
       ];
     }),
-  ) as Record<FolksChainId, PublicClient>;
+  ) as Record<FolksChainId, Client>;
 }
 
-export function getChainId(provider: PublicClient): EvmChainId {
+export function getChainId(provider: Client): EvmChainId {
   const chainId = provider.chain?.id;
   if (chainId === undefined)
     throw new Error("EVM provider chain id is undefined");

--- a/src/chains/evm/hub/modules/folks-hub-account.ts
+++ b/src/chains/evm/hub/modules/folks-hub-account.ts
@@ -1,3 +1,5 @@
+import { multicall } from "viem/actions";
+
 import { getFolksChainIdsByNetwork } from "../../../../common/utils/chain.js";
 import { getHubChain } from "../utils/chain.js";
 import { getAccountManagerContract } from "../utils/contract.js";
@@ -7,10 +9,10 @@ import type {
   FolksChainId,
 } from "../../../../common/types/chain.js";
 import type { AccountInfo } from "../types/account.js";
-import type { Address, Hex, PublicClient } from "viem";
+import type { Address, Client, Hex } from "viem";
 
 export async function getAccountInfo(
-  provider: PublicClient,
+  provider: Client,
   network: NetworkType,
   accountId: Hex,
   folksChainIds?: Array<FolksChainId>,
@@ -31,7 +33,7 @@ export async function getAccountInfo(
   };
 
   // query for registered and invited addresses on each respective chain
-  const registeredAddresses = await provider.multicall({
+  const registeredAddresses = await multicall(provider, {
     contracts: folksChainIds.map((folksChainId) => ({
       address: accountManager.address,
       abi: accountManager.abi,
@@ -41,7 +43,7 @@ export async function getAccountInfo(
     allowFailure: true,
   });
 
-  const invitedAddresses = await provider.multicall({
+  const invitedAddresses = await multicall(provider, {
     contracts: folksChainIds.map((folksChainId) => ({
       address: accountManager.address,
       abi: accountManager.abi,

--- a/src/chains/evm/hub/modules/folks-hub-loan.ts
+++ b/src/chains/evm/hub/modules/folks-hub-loan.ts
@@ -24,10 +24,10 @@ import type {
   MessageToSend,
 } from "../../../../common/types/message.js";
 import type { FolksTokenId } from "../../../../common/types/token.js";
-import type { Hex, PublicClient } from "viem";
+import type { Client, Hex } from "viem";
 
 export function getSendTokenAdapterFees(
-  provider: PublicClient,
+  provider: Client,
   network: NetworkType,
   accountId: Hex,
   folksTokenId: FolksTokenId,

--- a/src/chains/evm/hub/utils/contract.ts
+++ b/src/chains/evm/hub/utils/contract.ts
@@ -7,10 +7,10 @@ import { BridgeRouterHubAbi } from "../constants/abi/bridge-router-hub-abi.js";
 
 import type { GenericAddress } from "../../../../common/types/chain.js";
 import type { GetReadContractReturnType } from "../../common/types/contract.js";
-import type { Address, PublicClient, WalletClient } from "viem";
+import type { Address, Client, WalletClient } from "viem";
 
 export function getAccountManagerContract(
-  provider: PublicClient,
+  provider: Client,
   address: Address,
   signer?: WalletClient,
 ): GetReadContractReturnType<typeof AccountManagerAbi> {
@@ -22,7 +22,7 @@ export function getAccountManagerContract(
 }
 
 export function getBridgeRouterHubContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
 ): GetReadContractReturnType<typeof BridgeRouterHubAbi> {
   return getContract({

--- a/src/chains/evm/spoke/modules/folks-evm-account.ts
+++ b/src/chains/evm/spoke/modules/folks-evm-account.ts
@@ -39,16 +39,16 @@ import type {
 } from "../../common/types/module.js";
 import type {
   Address,
+  Client,
   EstimateGasParameters,
   Hex,
-  PublicClient,
   WalletClient,
 } from "viem";
 
 export const prepare = {
   async createAccount(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -70,7 +70,7 @@ export const prepare = {
 
   async inviteAddress(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -96,7 +96,7 @@ export const prepare = {
 
   async acceptInvite(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -118,7 +118,7 @@ export const prepare = {
 
   async unregisterAddress(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -143,7 +143,7 @@ export const prepare = {
 
 export const prepareRaw = {
   async createAccount(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -205,7 +205,7 @@ export const prepareRaw = {
   },
 
   async inviteAddress(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -275,7 +275,7 @@ export const prepareRaw = {
   },
 
   async acceptInvite(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -337,7 +337,7 @@ export const prepareRaw = {
   },
 
   async unregisterAddress(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -401,7 +401,7 @@ export const prepareRaw = {
 
 export const write = {
   async createAccount(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     prepareCall: PrepareCreateAccountCall,
@@ -438,7 +438,7 @@ export const write = {
   },
 
   async inviteAddress(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     folksChainIdToInvite: number,
@@ -480,7 +480,7 @@ export const write = {
   },
 
   async acceptInvite(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     prepareCall: PrepareAcceptInviteAddressCall,
@@ -517,7 +517,7 @@ export const write = {
   },
 
   async unregisterAddress(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     folksChainIdToUnregister: FolksChainId,

--- a/src/chains/evm/spoke/modules/folks-evm-loan.ts
+++ b/src/chains/evm/spoke/modules/folks-evm-loan.ts
@@ -52,14 +52,14 @@ import type {
   Address,
   EstimateGasParameters,
   Hex,
-  PublicClient,
+  Client,
   WalletClient,
 } from "viem";
 
 export const prepare = {
   async createLoan(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -85,7 +85,7 @@ export const prepare = {
 
   async deleteLoan(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -109,7 +109,7 @@ export const prepare = {
 
   async deposit(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -137,7 +137,7 @@ export const prepare = {
 
   async withdraw(
     folksChainId: FolksChainId,
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -172,7 +172,7 @@ export const prepare = {
 
 export const prepareRaw = {
   async createLoan(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -236,7 +236,7 @@ export const prepareRaw = {
   },
 
   async deleteLoan(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -299,7 +299,7 @@ export const prepareRaw = {
   },
 
   async deposit(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -376,7 +376,7 @@ export const prepareRaw = {
   },
 
   async withdraw(
-    provider: PublicClient,
+    provider: Client,
     sender: Address,
     network: NetworkType,
     accountId: Hex,
@@ -462,7 +462,7 @@ export const prepareRaw = {
 
 export const write = {
   async createLoan(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     loanId: Hex,
@@ -504,7 +504,7 @@ export const write = {
   },
 
   async deleteLoan(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     loanId: Hex,
@@ -542,7 +542,7 @@ export const write = {
   },
 
   async deposit(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     loanId: Hex,
@@ -591,7 +591,7 @@ export const write = {
   },
 
   async withdraw(
-    provider: PublicClient,
+    provider: Client,
     signer: WalletClient,
     accountId: Hex,
     loanId: Hex,

--- a/src/chains/evm/spoke/utils/contract.ts
+++ b/src/chains/evm/spoke/utils/contract.ts
@@ -8,19 +8,19 @@ import { SpokeTokenAbi } from "../constants/abi/spoke-token-abi.js";
 
 import type { GenericAddress } from "../../../../common/types/chain.js";
 import type { GetReadContractReturnType } from "../../common/types/contract.js";
-import type { GetContractReturnType, PublicClient, WalletClient } from "viem";
+import type { GetContractReturnType, Client, WalletClient } from "viem";
 
 export function getSpokeCommonContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
 ): GetReadContractReturnType<typeof SpokeCommonAbi>;
 export function getSpokeCommonContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer: WalletClient,
-): GetContractReturnType<typeof SpokeCommonAbi, PublicClient>;
+): GetContractReturnType<typeof SpokeCommonAbi, Client>;
 export function getSpokeCommonContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer?: WalletClient,
 ) {
@@ -32,7 +32,7 @@ export function getSpokeCommonContract(
 }
 
 export function getBridgeRouterSpokeContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer?: WalletClient,
 ): GetReadContractReturnType<typeof BridgeRouterSpokeAbi> {
@@ -44,16 +44,16 @@ export function getBridgeRouterSpokeContract(
 }
 
 export function getSpokeTokenContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
 ): GetReadContractReturnType<typeof SpokeTokenAbi>;
 export function getSpokeTokenContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer: WalletClient,
-): GetContractReturnType<typeof SpokeTokenAbi, PublicClient>;
+): GetContractReturnType<typeof SpokeTokenAbi, Client>;
 export function getSpokeTokenContract(
-  provider: PublicClient,
+  provider: Client,
   address: GenericAddress,
   signer?: WalletClient,
 ) {

--- a/src/common/types/core.ts
+++ b/src/common/types/core.ts
@@ -1,8 +1,5 @@
 import type { ChainType, NetworkType, FolksChainId } from "./chain.js";
-import type {
-  PublicClient as EVMProvider,
-  WalletClient as EVMSigner,
-} from "viem";
+import type { Client as EVMProvider, WalletClient as EVMSigner } from "viem";
 
 type FolksProviderTypeMap = {
   [ChainType.EVM]: EVMProvider;

--- a/src/xchain/core/folks-core.ts
+++ b/src/xchain/core/folks-core.ts
@@ -17,7 +17,7 @@ import type {
   FolksSignerType,
   FolksProvider,
 } from "../../common/types/core.js";
-import type { PublicClient as EVMProvider } from "viem";
+import type { Client as EVMProvider } from "viem";
 
 export class FolksCore {
   private static instance: FolksCore | undefined;


### PR DESCRIPTION
Replace `PublicClient` with `Client` to relax the required type and allow tree-shaking.

https://viem.sh/docs/clients/custom#tree-shaking