### PR TITLE
fix: convert generic address to lowercase

### DIFF
--- a/src/common/utils/address.ts
+++ b/src/common/utils/address.ts
@@ -18,7 +18,7 @@ import type { AccountId } from "../types/lending.js";
 export function getRandomGenericAddress(): GenericAddress {
   return pad(privateKeyToAccount(generatePrivateKey()).address, {
     size: BYTES32_LENGTH,
-  }) as GenericAddress;
+  }).toLowerCase() as GenericAddress;
 }
 
 export function isGenericAddress(address: GenericAddress): boolean {
@@ -37,7 +37,7 @@ export function convertToGenericAddress<T extends ChainType>(
     case ChainType.EVM:
       return pad(address as EvmAddress, {
         size: BYTES32_LENGTH,
-      }) as GenericAddress;
+      }).toLowerCase() as GenericAddress;
     default:
       return exhaustiveCheck(fromChainType);
   }


### PR DESCRIPTION
To create a generic address on evm chains via solidity, we have as a starting point [a parameter of type `address`](https://github.com/blockchain-italia/ff-xchain-smart-contracts/blob/449ec5c4e9a23732efcc5d368a93cf64ce33753a/contracts/bridge/libraries/Messages.sol#L58) (example on msg.sender). However, the `address` type is for all intents and purposes a hex and therefore has no concept of upper or lower case.

So the hex of generic address that is generated on chain, when converted to string (offchain), will be the padded lowercase version of the address.

This PR also simulates this behaviour on sdk to avoid inconsistencies, so even if `convertToGenericAddress` is passed a string address with checksums (mixed-case), the generated genericAddress will still be lowercase.